### PR TITLE
Add responsive PHP site scaffold with header and footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,77 @@
+/* Main stylesheet */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+}
+header {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  z-index: 1000;
+}
+.logo {
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+}
+nav a {
+  text-decoration: none;
+  color: #333;
+  transition: color 0.3s;
+}
+nav a:hover {
+  color: #007BFF;
+}
+.menu-toggle {
+  display: none;
+  flex-direction: column;
+  cursor: pointer;
+}
+.menu-toggle span {
+  width: 25px;
+  height: 3px;
+  background: #333;
+  margin: 4px 0;
+  transition: 0.4s;
+}
+@media (max-width: 768px) {
+  nav ul {
+    position: absolute;
+    top: 60px;
+    right: 0;
+    background: #fff;
+    flex-direction: column;
+    width: 200px;
+    display: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
+  nav ul.show {
+    display: flex;
+  }
+  .menu-toggle {
+    display: flex;
+  }
+}
+footer {
+  background: #f8f8f8;
+  text-align: center;
+  padding: 20px;
+  font-size: 0.9rem;
+}
+.social-icons span {
+  margin: 0 5px;
+}

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,10 @@
+<footer>
+  <p>Hill Country Awards &amp; Trophies</p>
+  <p>123 Placeholder St, Hill Country, TX 00000</p>
+  <p>Phone: (000) 000-0000 | Email: info@hillcountryawards.com</p>
+  <div class="social-icons">
+    <span>FB</span>
+    <span>TW</span>
+    <span>IG</span>
+  </div>
+</footer>

--- a/header.php
+++ b/header.php
@@ -1,0 +1,23 @@
+<header>
+  <div class="logo">Logo</div>
+  <div class="menu-toggle" onclick="toggleMenu()">
+    <span></span>
+    <span></span>
+    <span></span>
+  </div>
+  <nav>
+    <ul id="nav-links">
+      <li><a href="index.php">Home</a></li>
+      <li><a href="#">Awards &amp; Trophies</a></li>
+      <li><a href="#">About</a></li>
+      <li><a href="#">Clients</a></li>
+      <li><a href="#">Contact</a></li>
+    </ul>
+  </nav>
+</header>
+<script>
+function toggleMenu() {
+  var nav = document.getElementById('nav-links');
+  nav.classList.toggle('show');
+}
+</script>

--- a/index.php
+++ b/index.php
@@ -1,36 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>HCAT</title>
-    <style>
-        body {
-            margin: 0;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            min-height: 100vh;
-            background-color: #000;
-            color: #fff;
-            text-align: center;
-        }
-        .footer {
-            position: fixed;
-            bottom: 0;
-            width: 100%;
-            font-size: 0.8rem;
-            text-align: center;
-            color: #fff;
-            padding: 10px 0;
-        }
-        .footer a {
-            color: #fff;
-            text-decoration: none;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hill Country Awards &amp; Trophies</title>
+  <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <h1>Welcome to HCAT</h1>
-    <div class="footer">Copywrite 2025 <a href="http://www.cmschlosser.com">www.cmschlosser.com . All Rights Reserved!!!</a></div>
+  <?php include 'header.php'; ?>
+  <main>
+    <h1>Welcome to Hill Country Awards &amp; Trophies</h1>
+    <p>Your source for awards, trophies, and more.</p>
+  </main>
+  <?php include 'footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Create header.php and footer.php and link them into index.php for a shared layout.
- Add responsive navigation with hamburger toggle and text logo placeholder.
- Provide basic styling and sticky white header via css/style.css.
- Include placeholder footer contact info and social icons.
- Remove binary logo image, keeping an empty `images/` folder for future assets.

## Testing
- `php -l index.php header.php footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9b621dd0c8330a893fd8fa2d140d0