### PR TITLE
Implement homepage hero slideshow and favicon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,72 +61,49 @@ nav a:hover {
 .hero {
   position: relative;
   height: 100vh;
-  background: url('../images/hero/Americabg3.jpg') center/cover no-repeat;
+  overflow: hidden;
   color: #fff;
 }
 
-.hero .overlay {
+.hero .slide {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.5);
-}
-
-.hero-content {
-  position: relative;
-  z-index: 1;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  padding: 0 20px;
-}
-
-.tagline {
-  font-family: 'Dancing Script', cursive;
-  font-size: 4rem;
-  margin-bottom: 20px;
-}
-
-.carousel {
-  position: relative;
-  width: 100%;
-  max-width: 600px;
-}
-
-.slide {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+  background-size: cover;
+  background-position: center;
   opacity: 0;
   transition: opacity 1s ease-in-out;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
-.slide img {
-  width: 100%;
-  border-radius: 8px;
+.hero .slide.active {
+  opacity: 1;
 }
 
-.slide p {
+.hero .caption {
+  background: rgba(0,0,0,0.5);
+  padding: 20px;
+  border-radius: 4px;
+}
+
+.hero .caption h2 {
+  font-family: 'Dancing Script', cursive;
+  font-size: 4rem;
+}
+
+.hero .caption p {
   margin-top: 10px;
   font-weight: 600;
 }
 
-.slide.active {
-  opacity: 1;
-  position: relative;
-}
-
-.prev,
-.next {
+.hero .prev,
+.hero .next {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -137,11 +114,11 @@ nav a:hover {
   cursor: pointer;
 }
 
-.prev {
+.hero .prev {
   left: 10px;
 }
 
-.next {
+.hero .next {
   right: 10px;
 }
 

--- a/index.php
+++ b/index.php
@@ -4,36 +4,41 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hill Country Awards &amp; Trophies</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Dancing+Script:wght@700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-  <link rel="stylesheet" href="css/style.css">
-</head>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Dancing+Script:wght@700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="icon" type="image/png" href="images/logo/QA1_symbol.png">
+  </head>
 <body>
   <?php include 'header.php'; ?>
 
   <main>
-    <section class="hero">
-      <div class="overlay"></div>
-      <div class="hero-content">
-        <h1 class="tagline">When Memories Matter</h1>
-        <div class="carousel">
-          <div class="slide active">
-            <img src="images/hero/football1_slider3D_2.png" alt="Football Trophy">
-            <p>Rewarding Success with Perfection</p>
+      <section class="hero">
+        <div class="slide active" style="background-image:url('images/hero/football1_slider3D_2.png');">
+          <div class="caption">
+            <h2>When Memories Matter</h2>
           </div>
-          <div class="slide">
-            <img src="images/hero/champ_girl1.png" alt="Champion Girl">
-            <p>Effort Rewarded</p>
-          </div>
-          <div class="slide">
-            <img src="images/hero/celebration_1SLD.jpg" alt="Celebration">
-            <p>Celebrate Every Victory</p>
-          </div>
-          <button class="prev" aria-label="Previous slide">&#10094;</button>
-          <button class="next" aria-label="Next slide">&#10095;</button>
         </div>
-      </div>
-    </section>
+        <div class="slide" style="background-image:url('images/hero/celebration_1SLD.jpg');">
+          <div class="caption">
+            <h2>Celebrate</h2>
+          </div>
+        </div>
+        <div class="slide" style="background-image:url('images/hero/Americabg3.jpg');">
+          <div class="caption">
+            <h2>Reward</h2>
+            <p>Commending hard work</p>
+          </div>
+        </div>
+        <div class="slide" style="background-image:url('images/hero/champ_girl1.png');">
+          <div class="caption">
+            <h2>Drive</h2>
+            <p>Custom Recognition</p>
+          </div>
+        </div>
+        <button class="prev" aria-label="Previous slide">&#10094;</button>
+        <button class="next" aria-label="Next slide">&#10095;</button>
+      </section>
 
     <section class="about-preview">
       <div class="about-image">
@@ -63,9 +68,9 @@
   <?php include 'footer.php'; ?>
 
   <script>
-  const slides = document.querySelectorAll('.carousel .slide');
-  const nextBtn = document.querySelector('.carousel .next');
-  const prevBtn = document.querySelector('.carousel .prev');
+    const slides = document.querySelectorAll('.hero .slide');
+    const nextBtn = document.querySelector('.hero .next');
+    const prevBtn = document.querySelector('.hero .prev');
   let currentSlide = 0;
   function showSlide(index) {
     slides.forEach((slide, i) => {


### PR DESCRIPTION
## Summary
- Replace hero content with full-screen slideshow that crossfades between four award images and captions
- Style slideshow with centered captions, dark overlays, and navigation arrows
- Add site favicon referencing existing logo

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_68a9f5a0193c8330b59500efb948f12b