### PR TITLE
Fix hero slideshow styling and duplicate favicon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,19 +71,17 @@ nav a:hover {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   background-size: cover;
   background-position: center;
   opacity: 0;
   transition: opacity 1s ease-in-out;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
+  z-index: 0;
 }
 
 .hero .slide.active {
   opacity: 1;
+  z-index: 1;
 }
 
 .hero .overlay {
@@ -92,25 +90,31 @@ nav a:hover {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0,0,0,0.4);
   z-index: 0;
 }
 
 .hero .caption {
-  position: relative;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #fff;
+  font-family: 'Dancing Script', cursive;
+  font-size: 3rem;
   z-index: 1;
-  padding: 20px;
-  border-radius: 4px;
 }
 
 .hero .caption h2 {
-  font-family: 'Dancing Script', cursive;
-  font-size: 4rem;
+  font-family: inherit;
+  font-size: inherit;
 }
 
 .hero .caption p {
   margin-top: 10px;
-  font-weight: 600;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 1.2rem;
 }
 
 .hero .prev,
@@ -118,9 +122,9 @@ nav a:hover {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background: rgba(0,0,0,0.5);
+  background: rgba(255,255,255,0.5);
   border: none;
-  color: #fff;
+  color: #333;
   padding: 10px;
   cursor: pointer;
 }

--- a/header.php
+++ b/header.php
@@ -1,4 +1,3 @@
-<link rel="icon" type="image/x-icon" href="/images/logo/favicon.ico">
 <header>
   <div class="logo">
     <a href="index.php"><img src="images/logo/HCAT_logoSM.png" alt="Hill Country Awards &amp; Trophies logo"></a>


### PR DESCRIPTION
## Summary
- Ensure hero slides stack and fade properly with overlay and centered captions
- Style navigation arrows with white translucent background
- Remove duplicate favicon link so it's only in the head once

## Testing
- `php -l index.php header.php`

------
https://chatgpt.com/codex/tasks/task_e_68a9fa34378083308fbae0e910b59983