### PR TITLE
Use inline style for page-specific background images

### DIFF
--- a/layout.php
+++ b/layout.php
@@ -5,7 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/images/logo/favicon.ico">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Dancing+Script&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/style.css?bg=<?php echo urlencode($backgroundImage); ?>">
+    <link rel="stylesheet" href="/css/style.css">
+    <style>
+        body {
+            background: url('<?php echo htmlspecialchars($backgroundImage, ENT_QUOTES); ?>') no-repeat center center fixed;
+            background-size: cover;
+            height: 100vh;
+            margin: 0;
+            padding: 0;
+            font-family: 'Montserrat', sans-serif;
+        }
+    </style>
     <title>Hill Country Awards & Trophies</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Apply dynamic background images via an inline `<style>` block rather than query-string CSS
- Remove PHP query parameter from stylesheet link and preserve global CSS

## Testing
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa008bc2a083309e76f0f192978445