### PR TITLE
Refine layout and navigation styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,11 @@
 <?php
 header('Content-Type: text/css');
-$backgroundImage = isset($_GET['bg']) ? $_GET['bg'] : '';
 ?>
 body {
     margin: 0;
     font-family: 'Montserrat', sans-serif;
-    background: url(<?php echo $backgroundImage; ?>) no-repeat center center fixed;
-    background-size: cover;
-    background-position: center;
-    background-attachment: fixed;
+    color: #000;
+    background-color: #f9fcff;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -18,15 +15,20 @@ h1, h2, h3, h4, h5, h6 {
 header {
     position: sticky;
     top: 0;
-    background: rgba(255, 255, 255, 0.9);
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     padding: 0.5rem 1rem;
+    background: transparent;
 }
 
 header img {
-    height: 50px;
+    height: 25px;
+    margin-left: 0.5rem;
+}
+
+header nav {
+    margin-left: 2rem;
 }
 
 header nav ul {
@@ -39,7 +41,18 @@ header nav ul {
 
 header nav a {
     text-decoration: none;
-    color: inherit;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 1.1rem;
+    transition: color 0.3s;
+}
+
+header nav a:hover {
+    color: #fff;
+}
+
+header nav a.active {
+    border-bottom: 1px solid #fff;
+    font-weight: bold;
 }
 
 main section {
@@ -49,11 +62,20 @@ main section {
     border-radius: 4px;
 }
 
+main {
+    min-height: 800px;
+}
+
 footer {
     position: fixed;
     bottom: 0;
     width: 100%;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(0, 0, 0, 0.3);
     text-align: center;
     padding: 0.5rem 0;
+    color: #f0f0f0;
+}
+
+footer a {
+    color: inherit;
 }

--- a/layout.php
+++ b/layout.php
@@ -8,26 +8,33 @@
     <link rel="stylesheet" href="/css/style.css">
     <style>
         body {
-            background: url('<?php echo htmlspecialchars($backgroundImage, ENT_QUOTES); ?>') no-repeat center center fixed;
+            background-color: #f9fcff;
+            background-image: url('<?php echo htmlspecialchars($backgroundImage, ENT_QUOTES); ?>');
+            background-repeat: no-repeat;
+            background-attachment: scroll;
+            background-position: top center;
             background-size: cover;
             height: 100vh;
+            width: 100%;
             margin: 0;
             padding: 0;
             font-family: 'Montserrat', sans-serif;
+            color: #000;
         }
     </style>
     <title>Hill Country Awards & Trophies</title>
 </head>
 <body>
+<?php $currentPage = basename($_SERVER['PHP_SELF']); ?>
 <header>
     <img src="/images/logo/HCAT_logoSM.png" alt="Hill Country Awards &amp; Trophies">
     <nav>
         <ul>
-            <li><a href="/index.php">Home</a></li>
-            <li><a href="/awards.php">Awards &amp; Trophies</a></li>
-            <li><a href="/about.php">About</a></li>
-            <li><a href="/clients.php">Clients</a></li>
-            <li><a href="/contact.php">Contact</a></li>
+            <li><a href="/index.php" class="<?php echo $currentPage === 'index.php' ? 'active' : ''; ?>">Home</a></li>
+            <li><a href="/awards.php" class="<?php echo $currentPage === 'awards.php' ? 'active' : ''; ?>">Awards &amp; Trophies</a></li>
+            <li><a href="/about.php" class="<?php echo $currentPage === 'about.php' ? 'active' : ''; ?>">About</a></li>
+            <li><a href="/clients.php" class="<?php echo $currentPage === 'clients.php' ? 'active' : ''; ?>">Clients</a></li>
+            <li><a href="/contact.php" class="<?php echo $currentPage === 'contact.php' ? 'active' : ''; ?>">Contact</a></li>
         </ul>
     </nav>
 </header>
@@ -41,7 +48,7 @@ foreach ($files as $file) {
 ?>
 </main>
 <footer>
-    <p>&copy; Hill Country Awards &amp; Trophies</p>
+    <p>&copy; 2025 Hill Country Awards &amp; Trophies | Site designed and hosted by <a href="https://www.cmschlosser.com">Fiction Author C.M. Schlosser</a></p>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Make header and footer transparent, reduce logo size, and center navigation with active link highlighting.
- Pin background image to top with scrolling behavior and off-white fallback beyond the hero.
- Update footer copy and set pages to maintain minimum height.

## Testing
- `php -l layout.php`
- `php -l css/style.css`


------
https://chatgpt.com/codex/tasks/task_e_68aa043c986083308b559ddee3109eea