### PR TITLE
style: refine header layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,18 +17,20 @@ header {
     top: 0;
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
     padding: 0.5rem 1rem;
     background: transparent;
 }
 
 header img {
-    height: 25px;
-    margin-left: 0.5rem;
+    height: 12.5px;
+    margin-left: auto;
+    margin-right: 20px;
 }
 
 header nav {
-    margin-left: 2rem;
+    margin-left: 20px;
+    margin-right: auto;
 }
 
 header nav ul {
@@ -41,8 +43,8 @@ header nav ul {
 
 header nav a {
     text-decoration: none;
-    color: rgba(255, 255, 255, 0.9);
-    font-size: 1.1rem;
+    color: #fff;
+    font-size: 1.32rem;
     transition: color 0.3s;
 }
 

--- a/layout.php
+++ b/layout.php
@@ -11,7 +11,7 @@
             background-color: #f9fcff;
             background-image: url('<?php echo htmlspecialchars($backgroundImage, ENT_QUOTES); ?>');
             background-repeat: no-repeat;
-            background-attachment: scroll;
+            background-attachment: fixed;
             background-position: top center;
             background-size: cover;
             height: 100vh;


### PR DESCRIPTION
## Summary
- Resize logo and align to the right while positioning navigation to the left with larger white links
- Anchor page background image to the viewport so it remains visible behind the transparent header

## Testing
- `php -l css/style.css`
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa079133c883308c367bd491e84013