### PR TITLE
Refine header and footer styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,13 +19,20 @@ body {
     flex: 1;
     display: flex;
     flex-direction: column;
+    padding-top: 60px; /* space for fixed header */
 }
 
 header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 20px;
+    padding: 10px;
+    background: #333;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
 }
 
 .logo {
@@ -33,7 +40,7 @@ header {
 }
 
 .logo img {
-    max-height: 80px;
+    max-height: 40px;
 }
 
 nav {
@@ -55,7 +62,7 @@ nav a {
 }
 
 nav a.active {
-    border-bottom: 1px solid #fff;
+    border-bottom: 2px solid #fff;
 }
 
 main {
@@ -67,9 +74,23 @@ main {
 
 footer {
     margin-top: auto;
-    background: rgba(0, 0, 0, 0.6);
+    background: #333;
     color: #fff;
-    text-align: center;
-    padding: 10px 0;
+    padding: 20px;
+    text-align: left;
+}
+
+footer a {
+    color: #fff;
+}
+
+.footer-contact p {
+    margin: 0;
+    line-height: 1.4;
+}
+
+.footer-copy {
+    margin-top: 20px;
+    font-size: 0.9em;
 }
 

--- a/layout.php
+++ b/layout.php
@@ -36,7 +36,16 @@ $current_page = basename($_SERVER['PHP_SELF']);
         </main>
     </div>
     <footer>
-        &copy; 2025 Hill Country Awards | Website Design and Hosting by <a href="https://www.cmschlosser.com" target="_blank" rel="noopener noreferrer">Fiction Author C.M. Schlosser</a>
+        <div class="footer-contact">
+            <p><strong>ABOUT HILL COUNTRY AWARDS</strong></p>
+            <p>37 Years of excellence in Customer Service &amp; Quality</p>
+            <p>512.756.6712</p>
+            <p><a href="mailto:info@hillcountryawards.com">info@hillcountryawards.com</a></p>
+            <p>409 Industrial Blvd, St 1000<br>Burnet, Tx 78611</p>
+        </div>
+        <div class="footer-copy">
+            &copy; 2025 Hill Country Awards | Website Design and Hosting by <a href="https://www.cmschlosser.com" target="_blank" rel="noopener noreferrer">Fiction Author C.M. Schlosser</a>
+        </div>
     </footer>
     </body>
     </html>


### PR DESCRIPTION
## Summary
- Shrink header and logo, fix menu to top, and restore white navigation styling
- Apply dark grey backgrounds and add detailed contact info to footer

## Testing
- `php -l layout.php`
- `npx --yes stylelint css/style.css` *(fails: No configuration provided)*


------
https://chatgpt.com/codex/tasks/task_e_68ae23c0de2883309b46807348398e79