### PR TITLE
Add PHP image carousel to homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,3 +94,52 @@ footer a {
     font-size: 0.9em;
 }
 
+/* Carousel styles */
+.carousel {
+    position: relative;
+    width: 100%;
+    height: 400px;
+    overflow: hidden;
+}
+.carousel .slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    text-align: center;
+}
+.carousel .slide:first-child {
+    display: block;
+}
+.carousel img {
+    height: 100%;
+    width: auto;
+    max-width: 100%;
+    object-fit: contain;
+    margin: 0 auto;
+    display: block;
+}
+.carousel .caption {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.3);
+    padding: 10px 0;
+}
+.carousel .prev,
+.carousel .next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+}
+.carousel .prev { left: 10px; }
+.carousel .next { right: 10px; }
+

--- a/index.php
+++ b/index.php
@@ -1,9 +1,44 @@
 <?php
 $background = 'images/hero/bus1_home.jpg';
+$carouselDir = 'content/index/carousel';
+$carouselImages = [];
+if (is_dir($carouselDir)) {
+    foreach (scandir($carouselDir) as $file) {
+        if (preg_match('/\.(jpe?g|png|gif)$/i', $file)) {
+            $carouselImages[] = $file;
+        }
+    }
+}
+
+$contentDir = 'content/index';
+$contentFiles = [];
+if (is_dir($contentDir)) {
+    foreach (scandir($contentDir) as $file) {
+        if (pathinfo($file, PATHINFO_EXTENSION) === 'txt') {
+            $contentFiles[] = $file;
+        }
+    }
+}
+
 ob_start();
 ?>
-<h1>Welcome to Hill Country Awards</h1>
-<p>Your source for custom awards and engravings.</p>
+<?php if (!empty($carouselImages)) : ?>
+<div class="carousel">
+    <?php foreach ($carouselImages as $img) :
+        $caption = ucwords(str_replace(['-','_'], ' ', pathinfo($img, PATHINFO_FILENAME))); ?>
+    <div class="slide">
+        <img src="<?= $carouselDir . '/' . htmlspecialchars($img, ENT_QUOTES) ?>" alt="<?= htmlspecialchars($caption, ENT_QUOTES) ?>">
+        <div class="caption"><?= htmlspecialchars($caption) ?></div>
+    </div>
+    <?php endforeach; ?>
+    <button class="prev">&#10094;</button>
+    <button class="next">&#10095;</button>
+</div>
+<?php endif; ?>
+
+<?php foreach ($contentFiles as $file) : ?>
+    <p><?= htmlspecialchars(file_get_contents($contentDir . '/' . $file)) ?></p>
+<?php endforeach; ?>
 <?php
 $content = ob_get_clean();
 include 'layout.php';

--- a/layout.php
+++ b/layout.php
@@ -47,6 +47,28 @@ $current_page = basename($_SERVER['PHP_SELF']);
             &copy; 2025 Hill Country Awards | Website Design and Hosting by <a href="https://www.cmschlosser.com" target="_blank" rel="noopener noreferrer">Fiction Author C.M. Schlosser</a>
         </div>
     </footer>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const carousel = document.querySelector('.carousel');
+            if (!carousel) return;
+            const slides = carousel.querySelectorAll('.slide');
+            let index = 0;
+            const total = slides.length;
+            const nextBtn = carousel.querySelector('.next');
+            const prevBtn = carousel.querySelector('.prev');
+            function show(i) {
+                slides.forEach((s, idx) => { s.style.display = idx === i ? 'block' : 'none'; });
+                index = i;
+            }
+            function next() { show((index + 1) % total); }
+            function prev() { show((index - 1 + total) % total); }
+            let timer = setInterval(next, 5000);
+            function resetTimer() { clearInterval(timer); timer = setInterval(next, 5000); }
+            nextBtn.addEventListener('click', () => { next(); resetTimer(); });
+            prevBtn.addEventListener('click', () => { prev(); resetTimer(); });
+            show(0);
+        });
+    </script>
     </body>
     </html>
 


### PR DESCRIPTION
## Summary
- Implement PHP-driven carousel on index page that automatically scans `content/index/carousel` and captions images from filenames.
- Introduce responsive carousel styles and controls with vanilla JS for automatic and manual navigation.
- Initialize `content/index/carousel` directory for future images.

## Testing
- `php -l index.php layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae280c62108330a3f970f9471f421a